### PR TITLE
Fix sidechain citation

### DIFF
--- a/polkabtc-spec/docs/source/intro/CbA.rst
+++ b/polkabtc-spec/docs/source/intro/CbA.rst
@@ -54,7 +54,7 @@ Recommended Background Reading
 ------------------------------
 
 + **XCLAIM: Trustless, Interoperable, Cryptocurrency-backed Assets**. *IEEE Security and Privacy (S&P).* Zamyatin, A., Harz, D., Lind, J., Panayiotou, P., Gervais, A., & Knottenbelt, W. (2019).
-+ **Enabling Blockchain Innovations with Pegged Sidechains**. *Back, A., Corallo, M., Dashjr, L., Friedenbach, M., Maxwell, G., Miller, A., Poelstra A., Timon J.,  & Wuille, P*. (2019)
++ **Enabling Blockchain Innovations with Pegged Sidechains**. *Back, A., Corallo, M., Dashjr, L., Friedenbach, M., Maxwell, G., Miller, A., Poelstra A., Timon J.,  & Wuille, P*. (2014)
 + **SoK: Communication Across Distributed Ledgers**. *Cryptology ePrint Archiv, Report 2019/1128*. Zamyatin A, Al-Bassam M, Zindros D, Kokoris-Kogias E, Moreno-Sanchez P, Kiayias A, Knottenbelt WJ. (2019)
 + **Proof-of-Work Sidechains**. *Workshop on Trusted Smart Contracts, Financial Cryptography* Kiayias, A., & Zindros, D. (2018)
 


### PR DESCRIPTION
I was checking out your parachain spec and came across a minor typo on a citation of the sidechain paper, this trivial PR fixes it.

Xclaim's citation year also seems to be wrong but given that you are its authors I imagine that you took into account something that escapes me.

Feel free to close this PR if it's not important, at the end of the day, this is just a minor typo.